### PR TITLE
Fix for #4

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -46,7 +46,7 @@
             <ul>
                 {{ $page_link := .Permalink }}
                 {{ $tags := .Params.tags }}
-                {{ range .Site.Recent }}
+                {{ range .Site.Pages }}
                 {{ $page := . }}
                 {{ $has_common_tags := intersect $tags .Params.tags | len | lt 0 }}
                 {{ if and $has_common_tags (ne $page_link $page.Permalink) }}


### PR DESCRIPTION
This commit resolves #4 so that the "recent posts" section of the
template correctly shows the correct information with newer versions of
Hugo.
