### PR TITLE
Add support for changing the name convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Params:
   DateForm: "Mon, Jan 2, 2006"
   GoogleAnalyticsUserID: "Your ID."
   GravatarHash: "Your Hash."
+  GravatarNameConvention: "LastnameFirstname"
   Facebook: "Your ID."
   Twitter: "Your ID."
   Github: "Your ID."

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ Params:
   DateForm: "Mon, Jan 2, 2006"
   GoogleAnalyticsUserID: "Your ID."
   GravatarHash: "Your Hash."
+  GravatarNameConvention: "LastnameFirstname"
   Facebook: "Your ID."
   Twitter: "Your ID."
   Github: "Your ID."

--- a/layouts/partials/default_foot.html
+++ b/layouts/partials/default_foot.html
@@ -34,7 +34,14 @@ $(function() {
         .done(function(data) {
             var entry = data.entry[0];
             $("#photo").attr("src", entry.photos[0].value);
-            $("#username").html(entry.name.familyName + " " + entry.name.givenName);
+            {{ if and (isset .Site.Params "GravatarNameConvention") (eq (.Site.Params.GravatarNameConvention | html | lower) "firstnamelastname") }}{{/*
+            This if statement should allow people to swap the position of the
+            first and last name if they have (for example) a latin based name.
+            I don't know all of the different naming conventions used around
+            the world, but this should help with most names world-wide.
+            ~Frostyfrog
+            */}}$("#username").html(entry.name.givenName + " " + entry.name.familyName);{{ else }}{{/*
+            */}}$("#username").html(entry.name.familyName + " " + entry.name.givenName);{{ end }}
             $("#description").html(entry.aboutMe);
             entry.urls.forEach(function(el){
                 $("#urls").append($("<li><a href='" + el.value + "'>" + el.title + "</a></li>"));


### PR DESCRIPTION
This commit adds support for changing the author's Gravatar name
convention. While the old code worked for those who like their family
name to be displayed first, it does not work for people who would rather
have their given name to be displayed first. Hopefully this code fixes
that problem in a graceful manner. （＾＾）
